### PR TITLE
Use invariant culture for double-to-string conversion when parsing timestamps

### DIFF
--- a/src/Gemstone.COMTRADE/Timestamp.cs
+++ b/src/Gemstone.COMTRADE/Timestamp.cs
@@ -67,7 +67,7 @@ namespace Gemstone.COMTRADE
 
             seconds += milliseconds;
 
-            parts[^1] = seconds.ToString("00.000000");
+            parts[^1] = seconds.ToString("00.000000", CultureInfo.InvariantCulture);
 
             lineImage = string.Join(":", parts).RemoveWhiteSpace();
 


### PR DESCRIPTION
This resolves #7