### PR TITLE
Avoid saturation when writing 32-bit binary values on ARM64

### DIFF
--- a/src/Gemstone.COMTRADE/Writer.cs
+++ b/src/Gemstone.COMTRADE/Writer.cs
@@ -732,7 +732,7 @@ namespace Gemstone.COMTRADE
                         output.Write(LittleEndian.GetBytes(fracSecValue), 0, 2);
                 }
 
-                output.Write(LittleEndian.GetBytes((ushort)value), 0, 2); // 16-bit binary integer values
+                output.Write(LittleEndian.GetBytes((short)value), 0, 2); // 16-bit binary integer values
             }
 
             // Make sure FRACSEC values are injected
@@ -778,7 +778,7 @@ namespace Gemstone.COMTRADE
                     value -= schema.AnalogChannels[i].Adder;
                     value /= schema.AnalogChannels[i].Multiplier;
 
-                    output.Write(LittleEndian.GetBytes((uint)value), 0, 4); // 32-bit binary integer values
+                    output.Write(LittleEndian.GetBytes((int)value), 0, 4); // 32-bit binary integer values
                 }
                 else
                 {


### PR DESCRIPTION
This will also avoid similar behavior on .NET 9, which was modified to mimic ARM64 behavior. See #9

Also uses `short` for 16-bit binary values to match conceptually with the COMTRADE standard.

> This standard supports three of these formats. The supported formats are 16 and 32 bit integer numbers defined according to the two’s complement system (hereinafter, referred to as “binary” and “binary32” data respectively), and 32 bit real numbers defined according to the IEEE Std 754TM-2008 (hereinafter, referred to as float32 data).